### PR TITLE
GlfwWindow reforged to make possible multi-windowing 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,7 @@ target_link_libraries(some_cool_project glm assimp::assimp globjects::globjects
 	glfw spdlog::spdlog spdlog::spdlog_header_only soil2)
 target_compile_definitions(some_cool_project PRIVATE GLFW_INCLUDE_NONE)
 
+add_definitions(-DGLFW_INCLUDE_NONE)
+
 set_property(TARGET some_cool_project PROPERTY VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 set_property(TARGET some_cool_project PROPERTY CXX_STANDARD 17)

--- a/src/glfw_application.cpp
+++ b/src/glfw_application.cpp
@@ -10,9 +10,9 @@ GlfwApplication& GlfwApplication::get()
 }
 
 
-std::shared_ptr<GlfwWindow> GlfwApplication::createWindow()
+std::shared_ptr<GlfwWindow> GlfwApplication::createWindow(GlfwContextParameters parameters)
 {
-    auto pWindow = new GlfwWindow({});
+    auto pWindow = new GlfwWindow(parameters);
     std::shared_ptr<GlfwWindow> window { pWindow };
 
     std::lock_guard lock { windows_registry_mutex };

--- a/src/glfw_application.cpp
+++ b/src/glfw_application.cpp
@@ -1,0 +1,68 @@
+#include "glfw_application.h"
+
+//#include <GLFW/glfw3.h>
+
+
+GlfwApplication& GlfwApplication::get()
+{
+    static GlfwApplication keeper;
+    return keeper;
+}
+
+
+std::shared_ptr<GlfwWindow> GlfwApplication::createWindow()
+{
+    auto pWindow = new GlfwWindow({});
+    std::shared_ptr<GlfwWindow> window { pWindow };
+
+    std::lock_guard lock { windows_registry_mutex };
+    windows_registry.push_back(window);
+
+    return window;
+}
+
+void GlfwApplication::run()
+{
+    while (!exit_triggered)
+    {
+        {
+            std::lock_guard lock{ windows_registry_mutex };
+
+            windows_registry.erase(std::remove_if(std::begin(windows_registry), std::end(windows_registry), 
+           [](std::shared_ptr<GlfwWindow>& window)
+                {
+                    if (window->getCloseFlag() || window.use_count() == 1)
+                    {
+                        window->Close();
+                        return true; //
+                    }
+
+                    window->UpdateAndRender();
+                    return false;
+                }
+            ), std::end(windows_registry));
+
+        }
+
+        if (windows_registry.empty() && OnNoActiveWindows)
+            OnNoActiveWindows();
+
+        glfwPollEvents();
+    }
+}
+
+GlfwApplication::GlfwApplication()
+{
+    if (!glfwInit())
+        throw GlfwException("Initialization failed");
+
+    glfwSetErrorCallback([](int, const char* message)
+    {
+        throw GlfwException(message);
+    });
+}
+
+GlfwApplication::~GlfwApplication()
+{
+    glfwTerminate();
+}

--- a/src/glfw_application.h
+++ b/src/glfw_application.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <atomic>
+#include <vector>
+#include <functional>
+
+
+#include "glfw_window.h"
+
+class GlfwException : public std::runtime_error
+{
+public:
+    GlfwException(const char* reason) : std::runtime_error(reason)
+    {
+    }
+};
+
+
+class GlfwApplication
+{
+public:
+    static GlfwApplication& get();
+
+    GlfwApplication(const GlfwApplication&) = delete;
+    GlfwApplication(GlfwApplication&&) = delete;
+    GlfwApplication& operator=(const GlfwApplication&) = delete;
+    GlfwApplication& operator=(GlfwApplication&&) = delete;
+
+    std::function<void()> OnNoActiveWindows{};
+
+    //thread-safe
+    std::shared_ptr<GlfwWindow> createWindow();
+
+    //should be called once
+    void run();
+    void stop() { exit_triggered = true; }
+
+private:
+    GlfwApplication();
+    ~GlfwApplication();
+
+private:
+    std::atomic<bool> exit_triggered = false;
+    std::mutex windows_registry_mutex;
+    std::vector<std::shared_ptr<GlfwWindow>> windows_registry;
+};

--- a/src/glfw_application.h
+++ b/src/glfw_application.h
@@ -34,7 +34,7 @@ public:
     std::function<void()> OnNoActiveWindows{};
 
     //thread-safe
-    std::shared_ptr<GlfwWindow> createWindow();
+    std::shared_ptr<GlfwWindow> createWindow(GlfwContextParameters = {});
 
     //thread-safe
     template <typename T>

--- a/src/glfw_window.cpp
+++ b/src/glfw_window.cpp
@@ -12,14 +12,6 @@ GlfwWindow* GlfwWindow::FromNativeWindow(const GLFWwindow* window)
     return frontendPtr;
 }
 
-void GlfwWindow::TryUpdateGlBindings()
-{
-    globjects::init([](const char* name) 
-    {
-        return glfwGetProcAddress(name);
-    });
-}
-
 GlfwWindow::GlfwWindow(GlfwContextParameters contextParams) :
     context_parameters(contextParams)
 {
@@ -214,9 +206,6 @@ void GlfwWindow::MakeContextCurrent()
     if (actualContext != window_impl)
     {
         glfwMakeContextCurrent(window_impl);
-
-        //in common case gl functions must be updated after context switching, but fortunately in case "one context per one thread" it don't occured
-        TryUpdateGlBindings();
 
         if (swap_interval_need_update)
         {

--- a/src/glfw_window.cpp
+++ b/src/glfw_window.cpp
@@ -20,7 +20,11 @@ GlfwWindow::GlfwWindow(GlfwContextParameters contextParams) :
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, context_parameters.context_major_version);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, context_parameters.context_minor_version);
     glfwWindowHint(GLFW_OPENGL_PROFILE, static_cast<int>(context_parameters.profile));
+
     glfwWindowHint(GLFW_SAMPLES, context_parameters.msaa_samples);
+    glfwWindowHint(GLFW_REFRESH_RATE, context_parameters.refresh_rate);
+    glfwWindowHint(GLFW_SRGB_CAPABLE, context_parameters.srgb_capable);
+    glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, context_parameters.debug_context);
 
     /* Create a windowed mode window and its OpenGL context */
     window_impl = glfwCreateWindow(window_size.x, window_size.y, window_label.c_str(), nullptr, nullptr);

--- a/src/glfw_window.h
+++ b/src/glfw_window.h
@@ -14,12 +14,12 @@ public:
     MousePos(const MousePos&) = default;
     MousePos& operator=(const MousePos&) = default;
 
-    const glm::vec2& getPos() const noexcept { return position; }
-    glm::vec2 getDeltaPos() const noexcept { return position - previous_position; }
-    const glm::vec2& getPreviousPos() const noexcept { return previous_position; }
+    const glm::dvec2& getPos() const noexcept { return position; }
+    glm::dvec2 getDeltaPos() const noexcept { return position - previous_position; }
+    const glm::dvec2& getPreviousPos() const noexcept { return previous_position; }
 
 private:
-    glm::vec2 position, previous_position;
+    glm::dvec2 position, previous_position;
 };
 
 
@@ -42,7 +42,12 @@ struct GlfwContextParameters
     GlfwOpenglProfile profile = GlfwOpenglProfile::Core;
     int context_major_version = 4;
     int context_minor_version = 3;
-    int msaa_samples = 0;
+
+    int msaa_samples = GLFW_DONT_CARE;
+    int refresh_rate = GLFW_DONT_CARE;
+
+    bool srgb_capable = true;
+    bool debug_context = false;
 };
 
 
@@ -81,21 +86,21 @@ public:
     //event callbacks
     //Render context available only at InitializeCallback and RenderCallback
 
-    std::function<void(void)> InitializeCallback {};
+    std::function<void()> InitializeCallback {};
     std::function<void(double)> UpdateCallback {};
     std::function<void(double)> RenderCallback {};
-    std::function<void(void)> RefreshingCallback {};
+    std::function<void()> RefreshingCallback {};
 
     std::function<void(int)> KeyDownCallback {};
     std::function<void(int)> KeyUpCallback {};
     std::function<void(int)> KeyRepeatCallback {};
     std::function<void(const glm::ivec2&)> ResizeCallback {};
-    std::function<void(void)> ClosingCallback {};
+    std::function<void()> ClosingCallback {};
 
     std::function<void(const MousePos&)> MouseMoveCallback {};
     std::function<void(int)> MouseDownCallback {};
     std::function<void(int)> MouseUpCallback {};
-    std::function<void(glm::vec2)> MouseScrollCallback {};
+    std::function<void(glm::dvec2)> MouseScrollCallback {};
 
 protected:
     void OnInitialize() const { if (InitializeCallback) InitializeCallback(); }
@@ -103,28 +108,21 @@ protected:
     void OnRender(double deltaTime) const { if (RenderCallback) RenderCallback (deltaTime); }
     void OnWindowRefreshing() const { if (RefreshingCallback) RefreshingCallback(); }
 
-    void OnKeyDown(int key) const
-    {
-        if (KeyDownCallback)
-            KeyDownCallback(key);
-    }
+    void OnKeyDown(int key) const { if (KeyDownCallback) KeyDownCallback(key); }
 
-    void OnKeyUp(int key) const
-    {
-        if (KeyUpCallback)
-            KeyUpCallback(key);
-    }
+    void OnKeyUp(int key) const { if (KeyUpCallback) KeyUpCallback(key); }
     void OnKeyRepeat(int key) const { if (KeyRepeatCallback) KeyRepeatCallback(key); }
     
     void OnResize(glm::ivec2 newSize) const 
     { 
-        if (ResizeCallback) ResizeCallback(newSize); 
+        if (ResizeCallback) 
+            ResizeCallback(newSize); 
 
         window_size = newSize;
     }
     void OnClosing() const { if (ClosingCallback) ClosingCallback(); }
     
-    void OnMouseMove(glm::vec2 mousePosition) const 
+    void OnMouseMove(glm::dvec2 mousePosition) const 
     {
         mousePosition.y = window_size.y - mousePosition.y; //WTF?
 
@@ -135,7 +133,7 @@ protected:
     }
     void OnMouseDown(int button) const { if (MouseDownCallback) MouseDownCallback(button);}
     void OnMouseUp(int button) const { if (MouseUpCallback) MouseUpCallback(button); }
-    void OnMouseScroll(const glm::vec2& scrollDirection) const { if (MouseScrollCallback) MouseScrollCallback(scrollDirection); }
+    void OnMouseScroll(const glm::dvec2& scrollDirection) const { if (MouseScrollCallback) MouseScrollCallback(scrollDirection); }
 
 private:
     ///@thread_safety main thread

--- a/src/glfw_window.h
+++ b/src/glfw_window.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <globjects/globjects.h>
 #include <glm/glm.hpp>
 #include <GLFW/glfw3.h>
@@ -55,29 +56,31 @@ public:
     ///@thread_safety main thread
     bool isMouseKeyDown(int button) const;
 
-    ///@thread_safety main thread
+    ///@thread_safety safe
     GlfwWindow& setCursorMode(GlfwCursorMode cursorMode);
 
-    ///@thread_safety main thread
+    ///@thread_safety safe
     GlfwWindow& setLabel(const std::string& label);
     const std::string& getLabel() const { return window_label; }
 
-    ///@thread_safety main thread
+    ///@thread_safety safe
     GlfwWindow& setSize(int width, int height);
     const glm::ivec2& getSize() const { return window_size; }
 
-    ///@thread_safety main thread
+    ///@thread_safety safe
     void requestAttention();
 
-    ///@thread_safety any thread
+    ///@thread_safety safe
     GlfwWindow& setVSyncInterval(int interval);
 
-    ///@thread_safety any thread
+    ///@thread_safety safe
     GlfwWindow& setCloseFlag(bool flag);
     bool getCloseFlag() const;
 
 
     //event callbacks
+    //Render context available only at InitializeCallback and RenderCallback
+
     std::function<void(void)> InitializeCallback {};
     std::function<void(double)> UpdateCallback {};
     std::function<void(double)> RenderCallback {};
@@ -156,11 +159,15 @@ private:
 
     std::string window_label{ "New window"};
 
-    bool isInitialized{ false };
+    bool is_initialized { false };
+    bool swap_interval_need_update { true };
 
     //mutables is just for track some parameters in callbacks
     mutable glm::ivec2 window_size { 800, 600 };
     mutable glm::vec2 previous_mouse_pos {};
+    mutable int swap_interval{ 0 };
+
+    mutable std::mutex mutex;
 
     double previous_render_time {0.0};
 };

--- a/src/glfw_window.h
+++ b/src/glfw_window.h
@@ -150,8 +150,6 @@ private:
     void UpdateAndRender();
 
     static GlfwWindow* FromNativeWindow(const GLFWwindow* window);
-    static void TryUpdateGlBindings();
-
 
 private:
     const GlfwContextParameters context_parameters;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -244,22 +244,29 @@ private:
 
 		camera.setProjection(glm::perspectiveFov(glm::radians(70.0), static_cast<double>(newSize.x), static_cast<double>(newSize.y), 1.0, 1000.0));
 
-		//recreate framebuffer_hdr
-		framebuffer_hdr_color1 = globjects::Texture::createDefault(gl::GL_TEXTURE_2D_MULTISAMPLE);
-		//framebuffer_hdr_color1->storage2D(1, gl::GL_RGBA16F, newSize);
-		framebuffer_hdr_color1->storage2DMultisample(8, gl::GL_RGBA16F, newSize, true);
-		framebuffer_hdr_depth = globjects::Texture::createDefault(gl::GL_TEXTURE_2D_MULTISAMPLE);
-		//framebuffer_hdr_depth->storage2D(1, gl::GL_DEPTH_COMPONENT32F, newSize);
-		framebuffer_hdr_depth->storage2DMultisample(8, gl::GL_DEPTH_COMPONENT32F, newSize, true);
-
-		framebuffer_hdr->attachTexture(gl::GLenum::GL_COLOR_ATTACHMENT0, framebuffer_hdr_color1.get());
-		framebuffer_hdr->attachTexture(gl::GLenum::GL_DEPTH_ATTACHMENT, framebuffer_hdr_depth.get());
-		framebuffer_hdr->setDrawBuffers({ gl::GLenum::GL_COLOR_ATTACHMENT0, gl::GL_DEPTH_ATTACHMENT });
-		framebuffer_hdr->printStatus();
+		dirty_framebuffers = true;
     }
 
 	void OnRender(double deltaTime)
 	{
+		if (dirty_framebuffers)
+		{
+			//recreate framebuffer_hdr
+			framebuffer_hdr_color1 = globjects::Texture::createDefault(gl::GL_TEXTURE_2D_MULTISAMPLE);
+			//framebuffer_hdr_color1->storage2D(1, gl::GL_RGBA16F, newSize);
+			framebuffer_hdr_color1->storage2DMultisample(8, gl::GL_RGBA16F, window->getSize(), true);
+			framebuffer_hdr_depth = globjects::Texture::createDefault(gl::GL_TEXTURE_2D_MULTISAMPLE);
+			//framebuffer_hdr_depth->storage2D(1, gl::GL_DEPTH_COMPONENT32F, newSize);
+			framebuffer_hdr_depth->storage2DMultisample(8, gl::GL_DEPTH_COMPONENT32F, window->getSize(), true);
+
+			framebuffer_hdr->attachTexture(gl::GLenum::GL_COLOR_ATTACHMENT0, framebuffer_hdr_color1.get());
+			framebuffer_hdr->attachTexture(gl::GLenum::GL_DEPTH_ATTACHMENT, framebuffer_hdr_depth.get());
+			framebuffer_hdr->setDrawBuffers({ gl::GLenum::GL_COLOR_ATTACHMENT0, gl::GL_DEPTH_ATTACHMENT });
+			framebuffer_hdr->printStatus();
+
+			dirty_framebuffers = false;
+		}
+
 		rc.active_camera = &camera;
 		rc.transforms.reset(camera.getView(), camera.getProjection());
 
@@ -330,8 +337,7 @@ private:
 	std::shared_ptr<globjects::Texture> framebuffer_hdr_depth;
 	std::unique_ptr<globjects::Framebuffer> framebuffer_hdr;
 
-	
-
+	bool dirty_framebuffers = true;
 	
 
 	Camera camera;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,7 +159,9 @@ public:
 
 		window->
 	        setLabel("Oh hi Mark"s).
-			setSize(1024, 768);
+			setSize(1024, 768).
+		    setCursorMode(GlfwCursorMode::Hidden)
+	    ;
 
 		//setup callbacks
 		window->InitializeCallback = [this] { OnInitialize(); };
@@ -211,7 +213,10 @@ public:
 private:
     void OnInitialize()
     {
-		//camera.setProjection(glm::perspective())
+		globjects::init([](const char* name)
+			{
+				return glfwGetProcAddress(name);
+			});
 
 		scene.addNode(ModelImporter::load("data/matball.glb"), glm::scale(glm::mat4{1.0f}, {10, 10, 10}));
 
@@ -262,8 +267,13 @@ private:
 			framebuffer_hdr->attachTexture(gl::GLenum::GL_COLOR_ATTACHMENT0, framebuffer_hdr_color1.get());
 			framebuffer_hdr->attachTexture(gl::GLenum::GL_DEPTH_ATTACHMENT, framebuffer_hdr_depth.get());
 			framebuffer_hdr->setDrawBuffers({ gl::GLenum::GL_COLOR_ATTACHMENT0, gl::GL_DEPTH_ATTACHMENT });
-			framebuffer_hdr->printStatus();
+			
+			if (framebuffer_hdr->checkStatus() != gl::GLenum::GL_FRAMEBUFFER_COMPLETE)
+			{
+				spdlog::error("Framebuffer is not complete: {0}", framebuffer_hdr->statusString());
+			}
 
+			
 			dirty_framebuffers = false;
 		}
 


### PR DESCRIPTION
Glfw guides requires that functions such as glfwPollEvents should be called from main thread only so that now main cycle moved to global Glfw singletone